### PR TITLE
add bin to core

### DIFF
--- a/code/core/bin/index.cjs
+++ b/code/core/bin/index.cjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const majorNodeVersion = parseInt(process.versions.node, 10);
+if (majorNodeVersion < 18) {
+  console.error('To run Storybook you need to have Node.js 18 or higher');
+  process.exit(1);
+}
+
+// The Storybook CLI has a catch block for all of its commands, but if an error
+// occurs before the command even runs, for instance, if an import fails, then
+// such error will fall under the uncaughtException handler.
+// This is the earliest moment we can catch such errors.
+process.once('uncaughtException', (error) => {
+  if (error.message.includes('string-width')) {
+    console.error(
+      [
+        '🔴 Error: It looks like you are having a known issue with package hoisting.',
+        'Please check the following issue for details and solutions: https://github.com/storybookjs/storybook/issues/22431#issuecomment-1630086092\n\n',
+      ].join('\n')
+    );
+  }
+
+  throw error;
+});
+
+require('../dist/bin/index.cjs');

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -27,150 +27,154 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./node-logger": {
+    "./internal/node-logger": {
       "types": "./dist/node-logger/index.d.ts",
       "import": "./dist/node-logger/index.js",
       "require": "./dist/node-logger/index.cjs"
     },
-    "./client-logger": {
+    "./internal/client-logger": {
       "types": "./dist/client-logger/index.d.ts",
       "import": "./dist/client-logger/index.js",
       "require": "./dist/client-logger/index.cjs"
     },
-    "./theming": {
+    "./internal/theming": {
       "types": "./dist/theming/index.d.ts",
       "import": "./dist/theming/index.js",
       "require": "./dist/theming/index.cjs"
     },
-    "./theming/create": {
+    "./internal/theming/create": {
       "types": "./dist/theming/create.d.ts",
       "import": "./dist/theming/create.js",
       "require": "./dist/theming/create.cjs"
     },
-    "./core-server": {
+    "./internal/core-server": {
       "types": "./dist/core-server/index.d.ts",
       "import": "./dist/core-server/index.js",
       "require": "./dist/core-server/index.cjs"
     },
-    "./core-server/presets/common-preset": {
+    "./internal/core-server/presets/common-preset": {
       "import": "./dist/core-server/presets/common-preset.js",
       "require": "./dist/core-server/presets/common-preset.cjs"
     },
-    "./core-server/presets/common-manager": {
+    "./internal/core-server/presets/common-manager": {
       "import": "./dist/core-server/presets/common-manager.js"
     },
-    "./core-server/presets/common-override-preset": {
+    "./internal/core-server/presets/common-override-preset": {
       "import": "./dist/core-server/presets/common-override-preset.js",
       "require": "./dist/core-server/presets/common-override-preset.cjs"
     },
-    "./core-events": {
+    "./internal/core-events": {
       "types": "./dist/core-events/index.d.ts",
       "import": "./dist/core-events/index.js",
       "require": "./dist/core-events/index.cjs"
     },
-    "./manager-errors": {
+    "./internal/manager-errors": {
       "types": "./dist/manager-errors.d.ts",
       "import": "./dist/manager-errors.js"
     },
-    "./preview-errors": {
+    "./internal/preview-errors": {
       "types": "./dist/preview-errors.d.ts",
       "import": "./dist/preview-errors.js",
       "require": "./dist/preview-errors.cjs"
     },
-    "./server-errors": {
+    "./internal/server-errors": {
       "types": "./dist/server-errors.d.ts",
       "import": "./dist/server-errors.js",
       "require": "./dist/server-errors.cjs"
     },
-    "./channels": {
+    "./internal/channels": {
       "types": "./dist/channels/index.d.ts",
       "import": "./dist/channels/index.js",
       "require": "./dist/channels/index.cjs"
     },
-    "./types": {
+    "./internal/types": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/types/index.js",
       "require": "./dist/types/index.cjs"
     },
-    "./csf-tools": {
+    "./internal/csf-tools": {
       "types": "./dist/csf-tools/index.d.ts",
       "import": "./dist/csf-tools/index.js",
       "require": "./dist/csf-tools/index.cjs"
     },
-    "./common": {
+    "./internal/common": {
       "types": "./dist/common/index.d.ts",
       "import": "./dist/common/index.js",
       "require": "./dist/common/index.cjs"
     },
-    "./builder-manager": {
+    "./internal/builder-manager": {
       "types": "./dist/builder-manager/index.d.ts",
       "import": "./dist/builder-manager/index.js",
       "require": "./dist/builder-manager/index.cjs"
     },
-    "./telemetry": {
+    "./internal/telemetry": {
       "types": "./dist/telemetry/index.d.ts",
       "import": "./dist/telemetry/index.js",
       "require": "./dist/telemetry/index.cjs"
     },
-    "./preview-api": {
+    "./internal/preview-api": {
       "types": "./dist/preview-api/index.d.ts",
       "import": "./dist/preview-api/index.js",
       "require": "./dist/preview-api/index.cjs"
     },
-    "./manager-api": {
+    "./internal/manager-api": {
       "types": "./dist/manager-api/index.d.ts",
       "import": "./dist/manager-api/index.js",
       "require": "./dist/manager-api/index.cjs"
     },
-    "./router": {
+    "./internal/router": {
       "types": "./dist/router/index.d.ts",
       "import": "./dist/router/index.js",
       "require": "./dist/router/index.cjs"
     },
-    "./components": {
+    "./internal/components": {
       "types": "./dist/components/index.d.ts",
       "import": "./dist/components/index.js",
       "require": "./dist/components/index.cjs"
     },
-    "./docs-tools": {
+    "./internal/docs-tools": {
       "types": "./dist/docs-tools/index.d.ts",
       "import": "./dist/docs-tools/index.js",
       "require": "./dist/docs-tools/index.cjs"
     },
-    "./manager/globals-module-info": {
+    "./internal/manager/globals-module-info": {
       "types": "./dist/manager/globals-module-info.d.ts",
       "import": "./dist/manager/globals-module-info.js",
       "require": "./dist/manager/globals-module-info.cjs"
     },
-    "./manager/globals": {
+    "./internal/manager/globals": {
       "types": "./dist/manager/globals.d.ts",
       "import": "./dist/manager/globals.js",
       "require": "./dist/manager/globals.cjs"
     },
-    "./preview/globals": {
+    "./internal/preview/globals": {
       "types": "./dist/preview/globals.d.ts",
       "import": "./dist/preview/globals.js",
       "require": "./dist/preview/globals.cjs"
     },
-    "./cli": {
+    "./internal/cli": {
       "types": "./dist/cli/index.d.ts",
       "import": "./dist/cli/index.js",
       "require": "./dist/cli/index.cjs"
     },
-    "./babel": {
+    "./internal/babel": {
       "types": "./dist/babel/index.d.ts",
       "import": "./dist/babel/index.js",
       "require": "./dist/babel/index.cjs"
     },
-    "./cli/bin": {
+    "./internal/cli/bin": {
       "types": "./dist/cli/bin/index.d.ts",
       "import": "./dist/cli/bin/index.js",
       "require": "./dist/cli/bin/index.cjs"
     },
-    "./preview/runtime": {
+    "./internal/bin": {
+      "import": "./dist/bin/index.js",
+      "require": "./dist/bin/index.cjs"
+    },
+    "./internal/preview/runtime": {
       "import": "./dist/preview/runtime.js"
     },
-    "./manager/globals-runtime": {
+    "./internal/manager/globals-runtime": {
       "import": "./dist/manager/globals-runtime.js"
     },
     "./package.json": "./package.json"
@@ -263,6 +267,7 @@
       ]
     }
   },
+  "bin": "./bin/index.cjs",
   "files": [
     "dist/**/*",
     "assets/**/*",

--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -46,6 +46,7 @@ export const getEntries = (cwd: string) => {
     define('src/cli/index.ts', ['node'], true),
     define('src/babel/index.ts', ['node'], true),
     define('src/cli/bin/index.ts', ['node'], true),
+    define('src/bin/index.ts', ['node'], false),
   ];
 };
 

--- a/code/core/scripts/helpers/generatePackageJsonFile.ts
+++ b/code/core/scripts/helpers/generatePackageJsonFile.ts
@@ -40,7 +40,7 @@ export async function generatePackageJsonFile(entries: ReturnType<typeof getEntr
       main
         .replace(/\/index\.tsx?/, '')
         .replace(/\.tsx?/, '')
-        .replace('dist/', '')
+        .replace('dist/', 'internal/')
     ] = content;
     return acc;
   }, {});

--- a/code/core/src/bin/index.ts
+++ b/code/core/src/bin/index.ts
@@ -1,0 +1,22 @@
+import { versions } from '@storybook/core/common';
+
+import { spawn } from 'child_process';
+
+const args = process.argv.slice(2);
+
+if (['dev', 'build'].includes(args[0])) {
+  require('@storybook/core/cli/bin');
+} else {
+  const proxiedArgs =
+    args[0] === 'init'
+      ? [`create-storybook@${versions.storybook}`, ...args.slice(1)]
+      : [`@storybook/cli@${versions.storybook}`, ...args];
+  const command = ['npx', '--yes', ...proxiedArgs];
+  const child = spawn(command[0], command.slice(1), { stdio: 'inherit', shell: true });
+  child.on('exit', (code) => {
+    if (code != null) {
+      process.exit(code);
+    }
+    process.exit(1);
+  });
+}

--- a/code/lib/cli/core/bin/index.cjs
+++ b/code/lib/cli/core/bin/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require('@storybook/core/bin');

--- a/code/lib/cli/core/bin/index.js
+++ b/code/lib/cli/core/bin/index.js
@@ -1,0 +1,1 @@
+export * from '@storybook/core/bin';

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -193,6 +193,10 @@
     },
     "./internal/preview/runtime": {
       "import": "./core/preview/runtime.js"
+    },
+    "./internal/bin": {
+      "import": "./core/bin/index.js",
+      "require": "./core/bin/index.cjs"
     }
   },
   "main": "dist/index.cjs",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6314,6 +6314,8 @@ __metadata:
   peerDependenciesMeta:
     prettier:
       optional: true
+  bin:
+    core: ./bin/index.cjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Test for commit 447caec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a unified CLI entry point for Storybook.
  - Routes dev/build to the built-in CLI and proxies other commands via npx, pinned to the current Storybook version.
  - Enforces Node.js v18+ for running the CLI.

- Bug Fixes
  - Adds early startup error handling with a clearer message for a known dependency hoisting issue, including a help link.

- Chores
  - Updates package metadata to expose the CLI via a bin entry and realigns exports under an internal namespace without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->